### PR TITLE
Removed redundant path to bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "cypress"
   ],
   "scripts": {
-    "test": "./node_modules/.bin/cypress run --env type=actual",
-    "base": "./node_modules/.bin/cypress run --env type=base",
+    "test": "cypress run --env type=actual",
+    "base": "cypress run --env type=base",
     "prepublish": "npm run jest && npm run lint && npm run prettier:check && npm run build",
-    "lint": "./node_modules/.bin/eslint 'src/**'",
-    "prebuild": "./node_modules/.bin/rimraf dist",
-    "build": "./node_modules/.bin/babel src --out-dir dist --extensions \".js\" --copy-files",
+    "lint": "eslint 'src/**'",
+    "prebuild": "rimraf dist",
+    "build": "babel src --out-dir dist --extensions \".js\" --copy-files",
     "prepare": "npm run build",
     "ci": "export SNAPSHOT_DIRECTORY=cypress/snapshots && npm run build && npm run base && npm test",
     "prettier:check": "prettier --check --trailing-comma es5 --single-quote --arrow-parens always \"src/**/*.js\"",

--- a/src/command.js
+++ b/src/command.js
@@ -11,7 +11,7 @@ function thresholdOption(defaultScreenshotOptions, params) {
     return params.errorThreshold;
   }
 
-  return defaultScreenshotOptions?.errorThreshold || 0;
+  return defaultScreenshotOptions ? defaultScreenshotOptions.errorThreshold || 0 : 0;
 }
 
 /** Take a screenshot and move the file to specified folder */

--- a/src/command.js
+++ b/src/command.js
@@ -11,7 +11,9 @@ function thresholdOption(defaultScreenshotOptions, params) {
     return params.errorThreshold;
   }
 
-  return defaultScreenshotOptions ? defaultScreenshotOptions.errorThreshold || 0 : 0;
+  return defaultScreenshotOptions
+    ? defaultScreenshotOptions.errorThreshold || 0
+    : 0;
 }
 
 /** Take a screenshot and move the file to specified folder */


### PR DESCRIPTION
Before anything **thank you so much for the work done @mighdoll to make this lib run on cypress 10**

When referencing a cli library, one can omit it's path and npm/yarn handles the resolution to path

This solves the building of the library on windows*